### PR TITLE
Remover código síncrono

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,10 +4,7 @@ from request_queue import RequestQueue
 from request_model import ScoreRequest
 from scheduler import start_scheduler
 import threading
-import time
-import requests
-# o que é threading? 
-# É uma biblioteca padrão do Python que permite a execução de múltiplas threads (linhas de execução) dentro de um mesmo processo. 
+
 app = Flask(__name__)
 queue = RequestQueue.get_instance() # Obtém a instância única da fila de requisições
 
@@ -23,35 +20,9 @@ def proxy_score():
     if not client_id or not cpf:
         return jsonify({"error": "client-id e cpf são obrigatórios"}), 400
     
-    url = f"https://score.hsborges.dev/api/score?cpf={cpf}"
-    start = time.time()
-
-    try:
-        resposta = requests.get(url, headers={
-            "client-id": client_id,
-            "accept": "application/json"
-        })
-        duration = time.time() - start
-        if resposta.status_code == 200:
-            dados = resposta.json()
-            return jsonify({
-                "cpf": cpf,
-                "client_id": client_id,
-                "score": dados.get("score"),
-                "latency": duration
-            }), 200
-        else:
-            return jsonify({
-                "cpf": cpf,
-                "client_id": client_id,
-                "error": f"Erro {resposta.status_code}"
-            }), resposta.status_code
-    except requests.exceptions.RequestException as e:
-        return jsonify({
-            "cpf": cpf,
-            "client_id": client_id,
-            "error": str(e)
-        }), 500
+    req = ScoreRequest(client_id=client_id, cpf=cpf)
+    queue.enqueue(req)
+    return jsonify({"status": "enfileirada", "cpf": cpf, "client_id": client_id})
 
 @app.route("/metrics", methods=["GET"])
 def metrics():

--- a/teste_proxy.py
+++ b/teste_proxy.py
@@ -14,7 +14,7 @@ def send_request(i, cpf):
     headers = {"client-id": str(i)}
     try:
         response = requests.get(url, headers=headers)
-        print(f"[{i}] CPF: {cpf}  → Score: {response.json().get('score')}")
+        print(f"[{i}] CPF: {cpf}")
     except Exception as e:
         print(f"[{i}] CPF: {cpf} → Erro: {e}")
 


### PR DESCRIPTION
O ajuste realizado anteriormente, retornava a resposta imediatamente.
Porém esse mesmo ajuste, ignora a fila e o scheduler, ou seja, não respeita o rate limit de 1 req/s.
Então foi optado por manter o enfileiramento assíncrono com o scheduler que consome a fila em segundo plano, respeitando TTL e prioridade.
